### PR TITLE
Detail view scaffolding + Dependency update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -912,22 +912,22 @@
       "integrity": "sha512-6It2EVfGskxZCQhuykrfnALg7oVeiI6KclWSmGDqB0AiInVrTGB9Jp9i4/Ad21u9Jde/voVQz6eFX/eSg/UsPA=="
     },
     "@emotion/is-prop-valid": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.7.3.tgz",
-      "integrity": "sha512-uxJqm/sqwXw3YPA5GXX365OBcJGFtxUVkB6WyezqFHlNe9jqUWH5ur2O2M8dGBz61kn1g3ZBlzUunFQXQIClhA==",
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.2.tgz",
+      "integrity": "sha512-ZQIMAA2kLUWiUeMZNJDTeCwYRx1l8SQL0kHktze4COT22occKpDML1GDUXP5/sxhOMrZO8vZw773ni4H5Snrsg==",
       "requires": {
-        "@emotion/memoize": "0.7.1"
+        "@emotion/memoize": "0.7.2"
       }
     },
     "@emotion/memoize": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.1.tgz",
-      "integrity": "sha512-Qv4LTqO11jepd5Qmlp3M1YEjBumoTHcHFdgPTQ+sFlIL5myi/7xu/POwP7IRu6odBdmLXdtIs1D6TuW6kbwbbg=="
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.2.tgz",
+      "integrity": "sha512-hnHhwQzvPCW1QjBWFyBtsETdllOM92BfrKWbUTmh9aeOlcVOiXvlPsK4104xH8NsaKfg86PTFsWkueQeUfMA/w=="
     },
     "@emotion/unitless": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.3.tgz",
-      "integrity": "sha512-4zAPlpDEh2VwXswwr/t8xGNDGg8RQiPxtxZ3qQEXyQsBV39ptTdESCjuBvGze1nLMVrxmTIKmnO/nAV8Tqjjzg=="
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.4.tgz",
+      "integrity": "sha512-kBa+cDHOR9jpRJ+kcGMsysrls0leukrm68DmFQoMIWQcXdr2cZvyvypWuGYT7U+9kAExUE7+T7r6G3C3A6L8MQ=="
     },
     "@hapi/address": {
       "version": "2.0.0",
@@ -2078,9 +2078,9 @@
       "integrity": "sha512-CxwvxrZ9OirpXQ201Ec57OmGhmI8/ui/GwTDy0hSp6CmRvgRC0pSair6Z04Ck+JStA0sMPZzSJ3uE4n17EXpPQ=="
     },
     "babel-plugin-styled-components": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-1.10.1.tgz",
-      "integrity": "sha512-F6R2TnPGNN6iuXCs0xQ+EsrunwNoWI55J5I8Pkd/+fzzbv1I4gFgTaZepMOVpLobYWU2XaLIm+73L0zD3CnOdQ==",
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-1.10.6.tgz",
+      "integrity": "sha512-gyQj/Zf1kQti66100PhrCRjI5ldjaze9O0M3emXRPAN80Zsf8+e1thpTpaXJXVHXtaM4/+dJEgZHyS9Its+8SA==",
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.0.0",
         "@babel/helper-module-imports": "^7.0.0",
@@ -5646,9 +5646,9 @@
       "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
     },
     "grommet": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/grommet/-/grommet-2.7.1.tgz",
-      "integrity": "sha512-1QkupZUg8JeKYP4VR6CC5dPcOnkyzdnZtbk9W+mO27lzGQEfvQS+7HrN9DRzQIGf1gsWmGaXCKmmHm2S9xeJig==",
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/grommet/-/grommet-2.7.4.tgz",
+      "integrity": "sha512-/6XGi9zEpFHCyOg5lFitUIqabqpygrPa2689eKRWTBfes7kRIa5UwmUqfZUDllI/WoT6ZIksST/YiQqun5Gm/w==",
       "requires": {
         "css": "^2.2.3",
         "grommet-icons": "^4.2.0",
@@ -6443,9 +6443,9 @@
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "is-what": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/is-what/-/is-what-3.2.3.tgz",
-      "integrity": "sha512-c4syLgFnjXTH5qd82Fp/qtUIeM0wA69xbI0KH1QpurMIvDaZFrS8UtAa4U52Dc2qSznaMxHit0gErMp6A/Qk1w=="
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-3.2.4.tgz",
+      "integrity": "sha512-0awkPsfVd85bYStP99EqLxKvhc5SiE70hSZCPxJN2SYZ5d+IkX+r1Ri0qnPWPnuRVFrqrEnI3JgFN3yrGtjXaw=="
     },
     "is-windows": {
       "version": "1.0.2",
@@ -7896,9 +7896,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -8075,9 +8075,9 @@
       }
     },
     "memoize-one": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.0.4.tgz",
-      "integrity": "sha512-P0z5IeAH6qHHGkJIXWw0xC2HNEgkx/9uWWBQw64FJj3/ol14VYdfVGWWr0fXfjhhv3TKVIqUq65os6O4GUNksA=="
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.0.5.tgz",
+      "integrity": "sha512-ey6EpYv0tEaIbM/nTDOpHciXUvd+ackQrJgEzBwemhZZIWZjcyodqEcrmqDy2BKRTM3a65kKBV4WtLXJDt26SQ=="
     },
     "memory-fs": {
       "version": "0.4.1",
@@ -8089,11 +8089,11 @@
       }
     },
     "merge-anything": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/merge-anything/-/merge-anything-2.2.5.tgz",
-      "integrity": "sha512-WgZGR7EQ1D8pyh57uKBbkPhUCJZLGdMzbDaxL4MDTJSGsvtpGdm8myr6DDtgJwT46xiFBlHqxbveDRpFBWlKWQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/merge-anything/-/merge-anything-2.4.0.tgz",
+      "integrity": "sha512-MhJcPOEcDUIbwU0LnEfx5S9s9dfQ/KPu4g2UA5T5G1LRKS0XmpDvJ9+UUfTkfhge+nA1gStE4tJAvx6lXLs+rg==",
       "requires": {
-        "is-what": "^3.2.3"
+        "is-what": "^3.2.4"
       }
     },
     "merge-deep": {
@@ -8244,9 +8244,9 @@
       }
     },
     "mixin-deep": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
       "requires": {
         "for-in": "^1.0.2",
         "is-extendable": "^1.0.1"
@@ -11028,9 +11028,9 @@
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "set-value": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
       "requires": {
         "extend-shallow": "^2.0.1",
         "is-extendable": "^0.1.1",
@@ -11616,12 +11616,13 @@
       }
     },
     "styled-components": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-4.3.1.tgz",
-      "integrity": "sha512-04XKQFFSEx3qTeN5I4kiSeajrwG6juDMw2+vUgvfxeXFegE40TuPKS4fFey8RJP1Ii1AoVQVUOglrdUUey0ZHw==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-4.3.2.tgz",
+      "integrity": "sha512-NppHzIFavZ3TsIU3R1omtddJ0Bv1+j50AKh3ZWyXHuFvJq1I8qkQ5mZ7uQgD89Y8zJNx2qRo6RqAH1BmoVafHw==",
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
-        "@emotion/is-prop-valid": "^0.7.3",
+        "@babel/traverse": "^7.0.0",
+        "@emotion/is-prop-valid": "^0.8.1",
         "@emotion/unitless": "^0.7.0",
         "babel-plugin-styled-components": ">= 1",
         "css-to-react-native": "^2.2.2",
@@ -12058,35 +12059,14 @@
       }
     },
     "union-value": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
       "requires": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "set-value": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
-          }
-        }
+        "set-value": "^2.0.1"
       }
     },
     "uniq": {

--- a/package.json
+++ b/package.json
@@ -14,12 +14,12 @@
   },
   "homepage": "https://github.com/BritneyS/comic-web-detail#readme",
   "dependencies": {
-    "grommet": "^2.7.1",
+    "grommet": "^2.7.4",
     "grommet-icons": "^4.2.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-scripts": "3.0.1",
-    "styled-components": "^4.3.1"
+    "styled-components": "^4.3.2"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/App.js
+++ b/src/App.js
@@ -10,6 +10,122 @@ import AppBar from '../src/ui/AppBar';
 import HeroVillainTabs from '../src/ui/HeroVillianTabs';
 import CollapsibleDetailView from '../src/ui/sidebar/CollapsibleDetailView';
 import LayerDetailView from '../src/ui/sidebar/LayerDetailView';
+// TODO: move hero and villain objects to App.js + detail objects to pass as props
+const characters = {
+  heroes: [
+    {
+        name: 'batman',
+        image: {
+            url: '/images/batman.jpg'
+        }
+    },
+    {
+        name: 'superman',
+        image: {
+            url: '/images/superman.jpg'
+        }
+    },
+    {
+        name: 'deadpool',
+        image: {
+            url: '/images/deadpool.jpg'
+        }
+    },
+    {
+        name: 'wonder woman',
+        image: {
+            url: '/images/wonderwoman.jpg'
+        }
+    }
+  ],
+  villains: [
+    {
+        name: 'joker',
+        image: {
+            url: '/images/joker.jpg'
+        }
+    },
+    {
+        name: 'mr. freeze',
+        image: {
+            url: '/images/mrfreeze.png'
+        }
+    },
+    {
+        name: 'the penguin',
+        image: {
+            url: '/images/thepenguin.jpeg'
+        }
+    },
+    {
+        name: 'thanos',
+        image: {
+            url: '/images/thanos.png'
+        }
+    }
+  ]
+};
+const heroDetails = [
+  {
+      name: 'batman',
+      image: {
+          url: '/images/batman.jpg'
+      },
+      publisher: 'DC Comics'
+  },
+  {
+      name: 'superman',
+      image: {
+          url: '/images/superman.jpg'
+      },
+      publisher: 'DC Comics'
+  },
+  {
+      name: 'deadpool',
+      image: {
+          url: '/images/deadpool.jpg'
+      },
+      publisher: 'Marvel Comics'
+  },
+  {
+      name: 'wonder woman',
+      image: {
+          url: '/images/wonderwoman.jpg'
+      },
+      publisher: 'DC Comics'
+  }
+];
+
+const villainDetails = [
+  {
+      name: 'joker',
+      image: {
+          url: '/images/joker.jpg'
+      },
+      publisher: 'DC Comics'
+  },
+  {
+      name: 'mr. freeze',
+      image: {
+          url: '/images/mrfreeze.png'
+      },
+      publisher: 'DC Comics'
+  },
+  {
+      name: 'the penguin',
+      image: {
+          url: '/images/thepenguin.jpeg'
+      },
+      publisher: 'DC Comics'
+  },
+  {
+      name: 'thanos',
+      image: {
+          url: '/images/thanos.png'
+      },
+      publisher: 'Marvel Comics'
+  }
+];
 
 function App() {
   const [showSideBar, setShowSidebar] = useState(false);
@@ -26,12 +142,21 @@ function App() {
               <Box flex align='center' justify='center'>
                 <HeroVillainTabs
                   showSideBar={() => setShowSidebar(!showSideBar)}
+                  characters={characters}
                 />
               </Box>
               {(!showSideBar || size !== 'small') ? (
-                <CollapsibleDetailView showSideBar={showSideBar} />
+                <CollapsibleDetailView
+                  showSideBar={showSideBar}
+                  heroDetails={heroDetails}
+                  villainDetails={villainDetails}
+                />
               ) : (
-                <LayerDetailView setShowSidebar={() => setShowSidebar(false)} />
+                <LayerDetailView
+                  closeSidebar={() => setShowSidebar(false)}
+                  heroDetails={heroDetails}
+                  villainDetails={villainDetails}
+                />
               )}
             </Box>
           </Box>

--- a/src/App.js
+++ b/src/App.js
@@ -1,17 +1,15 @@
 import React, { useState } from 'react';
 import { 
-  Box, 
-  Button, 
-  Collapsible,
-  Grommet, 
-  Heading, 
-  Layer,
-  ResponsiveContext 
+  Box,
+  Grommet,
+  Heading,
+  ResponsiveContext
 } from 'grommet';
-import { FormClose } from 'grommet-icons';
 import theme from '../src/ui/theme';
 import AppBar from '../src/ui/AppBar';
 import HeroVillainTabs from '../src/ui/HeroVillianTabs';
+import CollapsibleDetailView from '../src/ui/sidebar/CollapsibleDetailView';
+import LayerDetailView from '../src/ui/sidebar/LayerDetailView';
 
 function App() {
   const [showSideBar, setShowSidebar] = useState(false);
@@ -31,41 +29,9 @@ function App() {
                 />
               </Box>
               {(!showSideBar || size !== 'small') ? (
-                <Collapsible direction="horizontal" open={showSideBar}>
-                  <Box
-                    flex
-                    width='medium'
-                    background='light-2'
-                    elevation='small'
-                    align='center'
-                    justify='center'
-                >
-                  sidebar
-                </Box>
-              </Collapsible>
+                <CollapsibleDetailView showSideBar={showSideBar} />
               ) : (
-                <Layer>
-                  <Box
-                    background='light-2'
-                    tag='header'
-                    justify='end'
-                    align='center'
-                    direction='row'
-                  >
-                    <Button
-                      icon={<FormClose />}
-                      onClick={() => setShowSidebar(false)}
-                    />
-                  </Box>
-                  <Box
-                    fill
-                    background='light-2'
-                    align='center'
-                    justify='center'
-                  >
-                    sidebar
-                  </Box>
-                </Layer>
+                <LayerDetailView setShowSidebar={() => setShowSidebar(false)} />
               )}
             </Box>
           </Box>

--- a/src/App.js
+++ b/src/App.js
@@ -10,7 +10,7 @@ import AppBar from '../src/ui/AppBar';
 import HeroVillainTabs from '../src/ui/HeroVillianTabs';
 import CollapsibleDetailView from '../src/ui/sidebar/CollapsibleDetailView';
 import LayerDetailView from '../src/ui/sidebar/LayerDetailView';
-// TODO: move hero and villain objects to App.js + detail objects to pass as props
+// TODO: Use redux to track/update state from main view to detail view
 const characters = {
   heroes: [
     {

--- a/src/ui/HeroVillianTabs.js
+++ b/src/ui/HeroVillianTabs.js
@@ -8,60 +8,6 @@ import {
   Button
 } from 'grommet';
 
-const heroes = [
-    {
-        name: 'batman',
-        image: {
-            url: '/images/batman.jpg'
-        }
-    },
-    {
-        name: 'superman',
-        image: {
-            url: '/images/superman.jpg'
-        }
-    },
-    {
-        name: 'deadpool',
-        image: {
-            url: '/images/deadpool.jpg'
-        }
-    },
-    {
-        name: 'wonder woman',
-        image: {
-            url: '/images/wonderwoman.jpg'
-        }
-    }
-];
-
-const villains = [
-    {
-        name: 'joker',
-        image: {
-            url: '/images/joker.jpg'
-        }
-    },
-    {
-        name: 'mr. freeze',
-        image: {
-            url: '/images/mrfreeze.png'
-        }
-    },
-    {
-        name: 'the penguin',
-        image: {
-            url: '/images/thepenguin.jpeg'
-        }
-    },
-    {
-        name: 'thanos',
-        image: {
-            url: '/images/thanos.png'
-        }
-    }
-];
-
 function HeroVillianTabs(props) {
     const imageStyle = {
         width:'100%',
@@ -72,7 +18,7 @@ function HeroVillianTabs(props) {
         <Tabs height='medium' flex='grow' alignSelf='start'>
             <Tab title='Heroes'>
                 <Box direction='row'>
-                {heroes.map ((hero, index) => {
+                {props.characters.heroes.map ((hero, index) => {
                     return (
                         <Box
                         key={index}
@@ -98,7 +44,7 @@ function HeroVillianTabs(props) {
             </Tab>
             <Tab title='Villains'>
                 <Box direction='row'>
-                {villains.map ((villain, index) => {
+                {props.characters.villains.map ((villain, index) => {
                     return (
                         <Box
                             key={index}

--- a/src/ui/sidebar/CollapsibleDetailView.js
+++ b/src/ui/sidebar/CollapsibleDetailView.js
@@ -2,9 +2,18 @@ import React from 'react';
 import { 
     Box,
     Collapsible,
+    Image,
+    Text
   } from 'grommet';
 
+
+
 function CollapsibleDetailView(props) {
+    const sidebarImageStyle = {
+        width:'100%',
+        height: 150
+    };
+
     return (
         <Collapsible direction="horizontal" open={props.showSideBar}>
             <Box
@@ -16,6 +25,14 @@ function CollapsibleDetailView(props) {
                 justify='center'
             >
                 sidebar
+                <Image
+                    fit='contain'
+                    alignSelf='center'
+                    src={props.heroDetails[0].image.url}
+                    style={sidebarImageStyle}
+                />
+                <Text>{props.heroDetails[0].name}</Text>
+                <Text>{props.heroDetails[0].publisher}</Text>
             </Box>
         </Collapsible>
     );

--- a/src/ui/sidebar/CollapsibleDetailView.js
+++ b/src/ui/sidebar/CollapsibleDetailView.js
@@ -24,7 +24,6 @@ function CollapsibleDetailView(props) {
                 align='center'
                 justify='center'
             >
-                sidebar
                 <Image
                     fit='contain'
                     alignSelf='center'

--- a/src/ui/sidebar/CollapsibleDetailView.js
+++ b/src/ui/sidebar/CollapsibleDetailView.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { 
+    Box,
+    Collapsible,
+  } from 'grommet';
+
+function CollapsibleDetailView(props) {
+    return (
+        <Collapsible direction="horizontal" open={props.showSideBar}>
+            <Box
+                flex
+                width='medium'
+                background='light-2'
+                elevation='small'
+                align='center'
+                justify='center'
+            >
+                sidebar
+            </Box>
+        </Collapsible>
+    );
+}
+
+export default CollapsibleDetailView;

--- a/src/ui/sidebar/LayerDetailView.js
+++ b/src/ui/sidebar/LayerDetailView.js
@@ -18,7 +18,7 @@ function LayerDetailView(props) {
             >
             <Button
                 icon={<FormClose />}
-                onClick={props.setShowSidebar}
+                onClick={props.closeSidebar}
             />
             </Box>
             <Box

--- a/src/ui/sidebar/LayerDetailView.js
+++ b/src/ui/sidebar/LayerDetailView.js
@@ -2,11 +2,18 @@ import React from 'react';
 import { 
     Box,
     Button,
+    Image,
     Layer,
+    Text
   } from 'grommet';
   import { FormClose } from 'grommet-icons';
 
 function LayerDetailView(props) {
+    const sidebarImageStyle = {
+        width:'100%',
+        height: 150
+    };
+
     return (
         <Layer>
             <Box
@@ -28,6 +35,14 @@ function LayerDetailView(props) {
                 justify='center'
             >
             sidebar
+            <Image
+                fit='contain'
+                alignSelf='center'
+                src={props.heroDetails[0].image.url}
+                style={sidebarImageStyle}
+            />
+            <Text>{props.heroDetails[0].name}</Text>
+            <Text>{props.heroDetails[0].publisher}</Text>
             </Box>
         </Layer>
     );

--- a/src/ui/sidebar/LayerDetailView.js
+++ b/src/ui/sidebar/LayerDetailView.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { 
+    Box,
+    Button,
+    Layer,
+  } from 'grommet';
+  import { FormClose } from 'grommet-icons';
+
+function LayerDetailView(props) {
+    return (
+        <Layer>
+            <Box
+                background='light-2'
+                tag='header'
+                justify='end'
+                align='center'
+                direction='row'
+            >
+            <Button
+                icon={<FormClose />}
+                onClick={props.setShowSidebar}
+            />
+            </Box>
+            <Box
+                fill
+                background='light-2'
+                align='center'
+                justify='center'
+            >
+            sidebar
+            </Box>
+        </Layer>
+    );
+}
+
+export default LayerDetailView;

--- a/src/ui/sidebar/LayerDetailView.js
+++ b/src/ui/sidebar/LayerDetailView.js
@@ -34,14 +34,14 @@ function LayerDetailView(props) {
                 align='center'
                 justify='center'
             >
-            <Image
-                fit='contain'
-                alignSelf='center'
-                src={props.heroDetails[0].image.url}
-                style={sidebarImageStyle}
-            />
-            <Text>{props.heroDetails[0].name}</Text>
-            <Text>{props.heroDetails[0].publisher}</Text>
+                <Image
+                    fit='contain'
+                    alignSelf='center'
+                    src={props.heroDetails[0].image.url}
+                    style={sidebarImageStyle}
+                />
+                <Text>{props.heroDetails[0].name}</Text>
+                <Text>{props.heroDetails[0].publisher}</Text>
             </Box>
         </Layer>
     );

--- a/src/ui/sidebar/LayerDetailView.js
+++ b/src/ui/sidebar/LayerDetailView.js
@@ -34,7 +34,6 @@ function LayerDetailView(props) {
                 align='center'
                 justify='center'
             >
-            sidebar
             <Image
                 fit='contain'
                 alignSelf='center'


### PR DESCRIPTION
## What does this PR do :question:
This PR refactors the two detail views into the `CollapsibleDetailView` (the desktop detail view) and the `LayerDetailView` (the mobile view). Basic scaffolding of the detail views were added, as well as sample data that could populate the views once state management is added.

This PR also contains dependency updates and automated vulnerability fixes.

## How to test it :microscope:
1. Check out this branch.
2. Run `npm install && npm start`.
3. Open the browser to http://localhost:3000/ if the page doesn't open automatically.
4. Click both the "Heroes" and "Villains" tabs. Four images representing either comic book heroes or villains should appear each time.
5. Click any image multiple times. The sidebar section should appear and disappear (see gif).
6. Resize the width of the window to its smallest size, then click any image again. The sidebar section should appear over the entire screen.
7. Click the `X` button in the top right corner of the screen. The sidebar should disappear again.


## Any background info you would like to include :white_check_mark:
N/A


## Screenshots (if applicable) :camera:
![comic-web-detail-pr-detail-view-scaffolding](https://user-images.githubusercontent.com/8409475/61572500-d64bea00-aa6c-11e9-9251-9d996e46bd75.gif)
